### PR TITLE
Add Amiga Pro Joystick to buttonmap.xml and topology.xml

### DIFF
--- a/game.libretro.uae/addon.xml.in
+++ b/game.libretro.uae/addon.xml.in
@@ -6,7 +6,7 @@
 	<requires>
 		<import addon="game.libretro" version="1.0.0"/>
 		<import addon="game.controller.amiga.cd32" version="1.0.0"/>
-		<import addon="game.controller.default" version="1.0.0"/>
+		<import addon="game.controller.amiga.pro.joystick" version="1.0.0"/>
 		<import addon="game.controller.keyboard" version="1.0.0"/>
 		<import addon="game.controller.mouse" version="1.0.0"/>
 	</requires>

--- a/game.libretro.uae/resources/buttonmap.xml
+++ b/game.libretro.uae/resources/buttonmap.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <buttonmap version="2">
-  <controller id="game.controller.amiga.cd32" type="RETRO_DEVICE_ANALOG" subclass="1">
+  <controller id="game.controller.amiga.cd32">
     <feature name="up" mapto="RETRO_DEVICE_ID_JOYPAD_UP"/>
     <feature name="down" mapto="RETRO_DEVICE_ID_JOYPAD_DOWN"/>
     <feature name="right" mapto="RETRO_DEVICE_ID_JOYPAD_RIGHT"/>
@@ -18,21 +18,23 @@
     <feature name="r2" mapto="RETRO_DEVICE_ID_JOYPAD_R2"/>
     <feature name="l3" mapto="RETRO_DEVICE_ID_JOYPAD_L3"/>
     <feature name="r3" mapto="RETRO_DEVICE_ID_JOYPAD_R3"/>
+    <feature name="leftstick" mapto="RETRO_DEVICE_INDEX_ANALOG_LEFT"/>
+    <feature name="rightstick" mapto="RETRO_DEVICE_INDEX_ANALOG_RIGHT"/>
     -->
   </controller>
-  <controller id="game.controller.default" type="RETRO_DEVICE_ANALOG" subclass="2">
-    <feature name="b" mapto="RETRO_DEVICE_ID_JOYPAD_A"/>
-    <feature name="a" mapto="RETRO_DEVICE_ID_JOYPAD_B"/>
-    <feature name="y" mapto="RETRO_DEVICE_ID_JOYPAD_X"/>
-    <feature name="x" mapto="RETRO_DEVICE_ID_JOYPAD_Y"/>
-    <feature name="leftbumper" mapto="RETRO_DEVICE_ID_JOYPAD_L"/>
-    <feature name="rightbumper" mapto="RETRO_DEVICE_ID_JOYPAD_R"/>
-    <feature name="lefttrigger" mapto="RETRO_DEVICE_ID_JOYPAD_L2"/>
-    <feature name="righttrigger" mapto="RETRO_DEVICE_ID_JOYPAD_R2"/>
-    <feature name="leftthumb" mapto="RETRO_DEVICE_ID_JOYPAD_L3"/>
-    <feature name="rightthumb" mapto="RETRO_DEVICE_ID_JOYPAD_R3"/>
-    <feature name="start" mapto="RETRO_DEVICE_ID_JOYPAD_START"/>
-    <feature name="back" mapto="RETRO_DEVICE_ID_JOYPAD_SELECT"/>
+  <controller id="game.controller.amiga.pro.joystick">
+    <feature name="red" mapto="RETRO_DEVICE_ID_JOYPAD_B"/>
+    <feature name="blue" mapto="RETRO_DEVICE_ID_JOYPAD_A"/>
+    <feature name="green" mapto="RETRO_DEVICE_ID_JOYPAD_Y"/>
+    <feature name="yellow" mapto="RETRO_DEVICE_ID_JOYPAD_X"/>
+    <feature name="select" mapto="RETRO_DEVICE_ID_JOYPAD_SELECT"/>
+    <feature name="play" mapto="RETRO_DEVICE_ID_JOYPAD_START"/>
+    <feature name="rewind" mapto="RETRO_DEVICE_ID_JOYPAD_L"/>
+    <feature name="forward" mapto="RETRO_DEVICE_ID_JOYPAD_R"/>
+    <feature name="l2" mapto="RETRO_DEVICE_ID_JOYPAD_L2"/>
+    <feature name="r2" mapto="RETRO_DEVICE_ID_JOYPAD_R2"/>
+    <feature name="l3" mapto="RETRO_DEVICE_ID_JOYPAD_L3"/>
+    <feature name="r3" mapto="RETRO_DEVICE_ID_JOYPAD_R3"/>
     <feature name="up" mapto="RETRO_DEVICE_ID_JOYPAD_UP"/>
     <feature name="down" mapto="RETRO_DEVICE_ID_JOYPAD_DOWN"/>
     <feature name="right" mapto="RETRO_DEVICE_ID_JOYPAD_RIGHT"/>

--- a/game.libretro.uae/resources/topology.xml
+++ b/game.libretro.uae/resources/topology.xml
@@ -7,11 +7,27 @@
     <accepts controller="game.controller.mouse"/>
   </port>
   <port type="controller" id="1">
-    <accepts controller="game.controller.amiga.cd32"/>
-    <accepts controller="game.controller.default"/>
+    <accepts controller="game.controller.amiga.cd32" type="RETRO_DEVICE_ANALOG" subclass="1"/>
+    <accepts controller="game.controller.amiga.pro.joystick" type="RETRO_DEVICE_ANALOG" subclass="2"/>
+    <accepts controller="game.controller.keyboard"/>
   </port>
   <port type="controller" id="2">
-    <accepts controller="game.controller.amiga.cd32"/>
-    <accepts controller="game.controller.default"/>
+    <accepts controller="game.controller.amiga.cd32" type="RETRO_DEVICE_ANALOG" subclass="1"/>
+    <accepts controller="game.controller.amiga.pro.joystick" type="RETRO_DEVICE_ANALOG" subclass="2"/>
+    <accepts controller="game.controller.keyboard"/>
+  </port>
+  <port type="controller" id="3">
+    <accepts controller="game.controller.amiga.pro.joystick" type="RETRO_DEVICE_ANALOG" subclass="0"/>
+    <accepts controller="game.controller.keyboard"/>
+  </port>
+  <port type="controller" id="4">
+    <accepts controller="game.controller.amiga.pro.joystick" type="RETRO_DEVICE_ANALOG" subclass="0"/>
+    <accepts controller="game.controller.keyboard"/>
+  </port>
+  <port type="controller" id="5" autoconnect="false">
+    <accepts controller="game.controller.keyboard"/>
+  </port>
+  <port type="controller" id="6" autoconnect="false">
+    <accepts controller="game.controller.keyboard"/>
   </port>
 </logicaltopology>


### PR DESCRIPTION
## Description

Adds the new Amiga Competition Pro joystick from https://github.com/kodi-game/controller-topology-project/pull/428 to the emulator's buttonmaps.

 Contains some temporary commented stuff, will be removed when controller add-on is merged upstream in repo-resources.

## Related PRs

* https://github.com/kodi-game/controller-topology-project/pull/428
* https://github.com/kodi-game/game.libretro/pull/155
* https://github.com/kodi-game/game.libretro.uae/pull/10

## Screenshots

<img width="1024" height="1024" alt="layout" src="https://github.com/user-attachments/assets/0512aa31-ce80-46ee-9d8e-3947d0e8b4a4" />
